### PR TITLE
Release/v1.0.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ drivers:
 prepare:
 	@echo "Cloning Drivers..."
 	git clone --branch kernel-6.12 https://github.com/prophesee-ai/linux-sensor-drivers.git drivers
+	git -C drivers checkout 7165d5e69ebed78dcc63b36e1d0f451c42aa7aaa
 #	touch drivers/.patched
 
 psee_sensors: drivers

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ It uses prophesee's [linux-sensor-drivers](https://github.com/prophesee-ai/linux
 1. Requirements:
     ``` bash
     sudo apt install raspberrypi-kernel-headers dkms
+    # raspberrypi-kernel-headers is not available any more on trixie. 
+    # sudo apt install "linux-headers-$(uname -r)"
     RPI_SENSOR_DRIVERS_PATH=$(pwd)
     ```
 2. Install drivers with dkms:
@@ -15,8 +17,8 @@ It uses prophesee's [linux-sensor-drivers](https://github.com/prophesee-ai/linux
     make prepare
     make all
     sudo dkms add .
-    sudo dkms build psee_sensor_drivers/1.0
-    sudo dkms install psee_sensor_drivers/1.0
+    sudo dkms build psee_sensor_drivers/1.0.1
+    sudo dkms install psee_sensor_drivers/1.0.1
     ```
 3. Install support software: [openeb](https://github.com/prophesee-ai/openeb.git)/5.1.1:
 
@@ -76,6 +78,7 @@ It uses prophesee's [linux-sensor-drivers](https://github.com/prophesee-ai/linux
     > the data recorded will contain invalid chunks, because our sensors output variable amounts of data that is stored in fixed size mipi frames (4096x391).
     >
     > To retrieve valid data, the mipi frames have to be cut at mipi frame end markers (which we inject on the sensor side).
+    > This cut is applied in openeb and controlled via environment variable: PSEE_VAR_V4L2_BSIZE
     > 
     > --> mipi frame end markers are encoded as "OTHER" events. They vary for event formats:
     > - EVT3: 0xE019

--- a/dkms.conf
+++ b/dkms.conf
@@ -1,5 +1,5 @@
 PACKAGE_NAME="psee_sensor_drivers"
-PACKAGE_VERSION="1.0"
+PACKAGE_VERSION="1.0.1"
 
 MAKE[0]="make all"
 CLEAN="make clean"

--- a/openeb-for-rpi.patch
+++ b/openeb-for-rpi.patch
@@ -1,16 +1,3 @@
-diff --git a/cmake/Modules/FindLibUSB.cmake b/cmake/Modules/FindLibUSB.cmake
-index 0cc3fb3..accdf69 100644
---- a/cmake/Modules/FindLibUSB.cmake
-+++ b/cmake/Modules/FindLibUSB.cmake
-@@ -52,7 +52,7 @@ else()
-     )
- 
-     find_library(LIBUSB_LIBRARY NAMES usb-1.0
--        PATHS ${PC_LIBUSB_LIBDIR} ${PC_LIBUSB_LIBRARY_DIRS}
-+        PATHS ${PC_LIBUSB_LIBDIR} ${PC_LIBUSB_LIBRARY_DIRS} /usr/lib/aarch64-linux-gnu
-     )        
-     
- endif(MSVC)
 diff --git a/hal_psee_plugins/include/boards/v4l2/dma_buf_heap.h b/hal_psee_plugins/include/boards/v4l2/dma_buf_heap.h
 index 1d8ff47..1339e6c 100644
 --- a/hal_psee_plugins/include/boards/v4l2/dma_buf_heap.h
@@ -334,6 +321,43 @@ index 7f1ae8d..106c1df 100644
          [[nodiscard]] int set_int(int value);
          [[nodiscard]] int set_int64(std::int64_t value);
          [[nodiscard]] int set_bool(bool value);
+diff --git a/hal_psee_plugins/psee_hw_layer_headers/include/metavision/psee_hw_layer/devices/v4l2/v4l2_ll_biases.h b/hal_psee_plugins/psee_hw_layer_headers/include/metavision/psee_hw_layer/devices/v4l2/v4l2_ll_biases.h
+index 4bdc465..b10877c 100644
+--- a/hal_psee_plugins/psee_hw_layer_headers/include/metavision/psee_hw_layer/devices/v4l2/v4l2_ll_biases.h
++++ b/hal_psee_plugins/psee_hw_layer_headers/include/metavision/psee_hw_layer/devices/v4l2/v4l2_ll_biases.h
+@@ -17,17 +17,20 @@
+ #include <vector>
+ 
+ #include "metavision/hal/facilities/i_ll_biases.h"
++#include "metavision/hal/facilities/i_hw_identification.h"
+ #include "metavision/psee_hw_layer/devices/common/bias_settings.h"
+ #include "metavision/psee_hw_layer/boards/v4l2/v4l2_controls.h"
+ 
+ namespace Metavision {
+ 
+ class RegisterMap;
++class I_HW_Identification;
+ class V4L2Controls;
+ 
+ class V4L2LLBiases : public I_LL_Biases {
+ public:
+-    V4L2LLBiases(const DeviceConfig &device_config, std::shared_ptr<V4L2Controls> controls, bool relative = false);
++    V4L2LLBiases(const DeviceConfig &device_config, const std::shared_ptr<I_HW_Identification> &hw_identification, 
++                 std::shared_ptr<V4L2Controls> controls, bool relative = false);
+ 
+     virtual std::map<std::string, int> get_all_biases() const override;
+ 
+@@ -57,8 +60,10 @@ private:
+     virtual bool get_bias_info_impl(const std::string &bias_name, LL_Bias_Info &info) const override;
+ 
+     std::shared_ptr<RegisterMap> register_map_;
++    std::shared_ptr<I_HW_Identification> hw_identification_;
+     int fd_;
+     bool relative_;
++    int bias_bitwidth_;
+ };
+ 
+ } // namespace Metavision
 diff --git a/hal_psee_plugins/psee_hw_layer_headers/include/metavision/psee_hw_layer/devices/v4l2/v4l2_sync.h b/hal_psee_plugins/psee_hw_layer_headers/include/metavision/psee_hw_layer/devices/v4l2/v4l2_sync.h
 new file mode 100644
 index 0000000..a42c5bb
@@ -652,11 +676,15 @@ index 4c1ebb4..91df6d8 100644
  }
  
 diff --git a/hal_psee_plugins/src/boards/v4l2/v4l2_controls.cpp b/hal_psee_plugins/src/boards/v4l2/v4l2_controls.cpp
-index 6014a29..f6669e5 100644
+index 6014a29..96ac099 100644
 --- a/hal_psee_plugins/src/boards/v4l2/v4l2_controls.cpp
 +++ b/hal_psee_plugins/src/boards/v4l2/v4l2_controls.cpp
-@@ -29,6 +29,8 @@ std::optional<int> V4L2Controls::V4L2Control::get_int(void) {
+@@ -27,8 +27,12 @@ std::optional<int> V4L2Controls::V4L2Control::get_int(void) {
+         return {};
+     }
  
++    refresh();
++
      switch(query_.type) {
          case V4L2_CTRL_TYPE_INTEGER:
 +        case V4L2_CTRL_TYPE_MENU:
@@ -664,7 +692,30 @@ index 6014a29..f6669e5 100644
              return std::optional<int>(static_cast<int>(ctrl.value));
          default:
              return {};
-@@ -71,11 +73,51 @@ std::optional<std::string> V4L2Controls::V4L2Control::get_str(void) {
+@@ -40,6 +44,8 @@ std::optional<int64_t> V4L2Controls::V4L2Control::get_int64(void) {
+         return {};
+     }
+ 
++    refresh();
++
+     switch(query_.type) {
+         case V4L2_CTRL_TYPE_INTEGER:
+             return std::optional<int64_t>(static_cast<int64_t>(ctrl.value));
+@@ -55,6 +61,8 @@ std::optional<bool> V4L2Controls::V4L2Control::get_bool(void) {
+         return {};
+     }
+ 
++    refresh();
++
+     switch(query_.type) {
+         case V4L2_CTRL_TYPE_BOOLEAN:
+             return std::optional<bool>(static_cast<bool>(ctrl.value));
+@@ -68,14 +76,56 @@ std::optional<std::string> V4L2Controls::V4L2Control::get_str(void) {
+         return {};
+     }
+ 
++    refresh();
++    
      switch(query_.type) {
          case V4L2_CTRL_TYPE_STRING:
              return std::string(ctrl.string);
@@ -717,7 +768,7 @@ index 6014a29..f6669e5 100644
      // guards
      if (query_.flags & V4L2_CTRL_FLAG_WRITE_ONLY)
 diff --git a/hal_psee_plugins/src/boards/v4l2/v4l2_data_transfer.cpp b/hal_psee_plugins/src/boards/v4l2/v4l2_data_transfer.cpp
-index 14b52a5..0aaa8e9 100644
+index 14b52a5..9de13c4 100644
 --- a/hal_psee_plugins/src/boards/v4l2/v4l2_data_transfer.cpp
 +++ b/hal_psee_plugins/src/boards/v4l2/v4l2_data_transfer.cpp
 @@ -30,7 +30,7 @@ namespace Metavision {
@@ -1218,7 +1269,7 @@ index efc43c2..a6e9f0b 100644
  
  void V4l2DataTransfer::DmabufAllocator::begin_cpu_access(void *vaddr) const {
 diff --git a/hal_psee_plugins/src/boards/v4l2/v4l2_hardware_identification.cpp b/hal_psee_plugins/src/boards/v4l2/v4l2_hardware_identification.cpp
-index 81e3501..62cb2f1 100644
+index 81e3501..87c8e98 100644
 --- a/hal_psee_plugins/src/boards/v4l2/v4l2_hardware_identification.cpp
 +++ b/hal_psee_plugins/src/boards/v4l2/v4l2_hardware_identification.cpp
 @@ -2,6 +2,7 @@
@@ -1298,9 +1349,12 @@ index 81e3501..62cb2f1 100644
      return ss.str();
  }
  std::string V4l2HwIdentification::get_integrator() const {
-@@ -93,4 +53,8 @@ std::string V4l2HwIdentification::get_connection_type() const {
+@@ -91,6 +51,10 @@ std::string V4l2HwIdentification::get_connection_type() const {
+ }
+ 
  DeviceConfigOptionMap V4l2HwIdentification::get_device_config_options_impl() const {
-     return {};
+-    return {};
++    return {{"ll_biases_range_check_bypass", DeviceConfigOption(true)}};
  }
 +
 +RawFileHeader V4l2HwIdentification::get_header_impl() const {
@@ -1401,7 +1455,7 @@ index 8cf80d2..45ff43d 100644
  
  } // namespace Metavision
 diff --git a/hal_psee_plugins/src/devices/v4l2/v4l2_device_builder.cpp b/hal_psee_plugins/src/devices/v4l2/v4l2_device_builder.cpp
-index 85ecf92..593212c 100644
+index 85ecf92..977cb0f 100644
 --- a/hal_psee_plugins/src/devices/v4l2/v4l2_device_builder.cpp
 +++ b/hal_psee_plugins/src/devices/v4l2/v4l2_device_builder.cpp
 @@ -18,6 +18,7 @@
@@ -1412,33 +1466,85 @@ index 85ecf92..593212c 100644
  #include "metavision/psee_hw_layer/devices/v4l2/v4l2_roi_interface.h"
  #include "metavision/psee_hw_layer/devices/v4l2/v4l2_crop.h"
  
-@@ -53,7 +54,7 @@ bool V4L2DeviceBuilder::build_device(std::shared_ptr<BoardCommand> cmd, DeviceBu
+@@ -52,14 +53,22 @@ bool V4L2DeviceBuilder::build_device(std::shared_ptr<BoardCommand> cmd, DeviceBu
+ 
      auto controls = ctrl->get_controls();
  
++    auto daim = hw_identification->get_device_config_options();
++    for (const auto &[key, option] : daim) {
++        MV_HAL_LOG_DEBUG() << "HW id Device config option: " << key << " = " << option;
++    }
++
      if (controls->has("bias")) {
 -        MV_HAL_LOG_TRACE() << "Found BIAS controls\n";
+-        auto sensor_info = hw_identification->get_sensor_info();
+-        bool relative    = false;
+-        if (sensor_info.name_ == "IMX636") {
+-            relative = true;
+-        }
+-        device_builder.add_facility(std::make_unique<V4L2LLBiases>(config, controls, relative));
 +        MV_HAL_LOG_TRACE() << "Found BIAS controls";
-         auto sensor_info = hw_identification->get_sensor_info();
-         bool relative    = false;
-         if (sensor_info.name_ == "IMX636") {
-@@ -62,6 +63,12 @@ bool V4L2DeviceBuilder::build_device(std::shared_ptr<BoardCommand> cmd, DeviceBu
-         device_builder.add_facility(std::make_unique<V4L2LLBiases>(config, controls, relative));
-     }
- 
++        DeviceConfig myconfig = config;
++        myconfig.enable_biases_range_check_bypass(true);
++        device_builder.add_facility(std::make_unique<V4L2LLBiases>(myconfig, hw_identification, controls));
++    }
++
 +    if (controls->has("sync"))
 +    {
 +        MV_HAL_LOG_TRACE() << "Found SYNC controls";
 +        device_builder.add_facility(std::make_unique<V4l2Synchronization>(controls));
-+    }
-+    
+     }
+ 
      if (controls->has("erc")) {
-         MV_HAL_LOG_TRACE() << "Found ERC controls";
-         device_builder.add_facility(std::make_unique<V4L2Erc>(controls));
 diff --git a/hal_psee_plugins/src/devices/v4l2/v4l2_ll_biases.cpp b/hal_psee_plugins/src/devices/v4l2/v4l2_ll_biases.cpp
-index c698ac6..84b224b 100644
+index c698ac6..c6cf920 100644
 --- a/hal_psee_plugins/src/devices/v4l2/v4l2_ll_biases.cpp
 +++ b/hal_psee_plugins/src/devices/v4l2/v4l2_ll_biases.cpp
-@@ -71,14 +71,24 @@ bool V4L2LLBiases::get_bias_info_impl(const std::string &bias_name, LL_Bias_Info
+@@ -10,14 +10,28 @@
+  **********************************************************************************************************************/
+ 
+ #include <cassert>
++#include <cmath>
+ #include "metavision/hal/utils/detail/hal_log_impl.h"
+ #include "metavision/psee_hw_layer/devices/v4l2/v4l2_ll_biases.h"
+ #include "metavision/psee_hw_layer/boards/v4l2/v4l2_controls.h"
+ 
+ namespace Metavision {
+ 
+-V4L2LLBiases::V4L2LLBiases(const DeviceConfig &device_config, std::shared_ptr<V4L2Controls> controls, bool relative) :
+-    I_LL_Biases(device_config), controls_(controls), relative_(relative) {
++V4L2LLBiases::V4L2LLBiases(const DeviceConfig &device_config, const std::shared_ptr<I_HW_Identification> &hw_identification, std::shared_ptr<V4L2Controls> controls, bool relative) :
++    I_LL_Biases(device_config), hw_identification_(hw_identification), controls_(controls) { 
++    auto sensor_info = hw_identification->get_sensor_info();
++    if (sensor_info.name_ == "IMX636") {
++        relative_ = true;
++	    bias_bitwidth_ = 8;
++    } else {
++        relative_ = false;
++	    bias_bitwidth_ = 7;
++    }
++
++    MV_HAL_LOG_TRACE() << "V4L2 Biases - Sensor info: " << sensor_info.name_;
++    MV_HAL_LOG_TRACE() << "V4L2 Biases - Relative   : " << relative_;
++    MV_HAL_LOG_TRACE() << "V4L2 Biases - Bit Width  : " << pow(2, bias_bitwidth_) - 1;
++
+     // reset all biases to default values
+     controls_->foreach ([&](V4L2Controls::V4L2Control &ctrl) {
+         auto name = std::string(ctrl.query_.name);
+@@ -62,8 +76,10 @@ int V4L2LLBiases::get_impl(const std::string &bias_name) const {
+ 
+ bool V4L2LLBiases::get_bias_info_impl(const std::string &bias_name, LL_Bias_Info &bias_info) const {
+     auto ctrl = controls_->get(bias_name);
+-    bias_info = LL_Bias_Info(0, 127, ctrl.query_.minimum, ctrl.query_.maximum, std::string("todo::description"), true,
+-                             std::string("todo::category"));
++    int offset = relative_ ? ctrl.query_.default_value : 0;
++    bias_info = LL_Bias_Info(0 - offset, pow(2, bias_bitwidth_) - 1 - offset, 
++                             ctrl.query_.minimum - offset, ctrl.query_.maximum - offset, 
++                             std::string("todo::description"), true, std::string("todo::category"));
+ 
+     return true;
+ }
+@@ -71,14 +87,24 @@ bool V4L2LLBiases::get_bias_info_impl(const std::string &bias_name, LL_Bias_Info
  std::map<std::string, int> V4L2LLBiases::get_all_biases() const {
      std::map<std::string, int> biases;
  

--- a/overlays/genx320-overlay.dts
+++ b/overlays/genx320-overlay.dts
@@ -67,7 +67,7 @@
 				rotation = <180>;
 				orientation = <2>;
 
-				rstn-delay-ms = <285>;
+				rstn-delay-ms = <385>;
 
 				port {
 					genx320_0: endpoint {

--- a/overlays/imx636-overlay.dts
+++ b/overlays/imx636-overlay.dts
@@ -67,7 +67,7 @@
 				rotation = <180>;
 				orientation = <2>;
 
-				rstn-delay-ms = <285>;
+				rstn-delay-ms = <385>;
 
 				port {
 					imx636_0: endpoint {

--- a/rp5_setup_v4l.sh
+++ b/rp5_setup_v4l.sh
@@ -2,57 +2,41 @@
 
 for d in {0..4}; do
     # Execute the command for the current -d value
-    OUTPUT=$(media-ctl -p -d "$d" | grep Sens)
+    SENSOR_TYPE=$(media-ctl -p -d "$d" | grep "entity" | grep -oE "imx636|genx320")
 
     # Check if the output is non-empty
-    if [[ -n "$OUTPUT" ]]; then
-        if [[ -n "$(media-ctl -p -d "$d" | grep genx320)" ]]; then
-            SENSOR_TYPE=genx320
+    if [[ -n "$SENSOR_TYPE" ]]; then
+        subdev_entity=$(media-ctl -d "$d" -p | awk -v entity="$SENSOR_TYPE" '$0 ~ "entity" && $0 ~ entity { in_entity=1 } in_entity && /device node name/ { print $NF; exit }')
+        read BUFFER_WIDTH BUFFER_HEIGHT <<<$(
+            v4l2-ctl -d $subdev_entity --list-subdev-framesizes pad=pad0 | sed -n 's/.*- //p' | tr 'x' ' ')
+        if [ "$SENSOR_TYPE" = "genx320" ] ; then
             IMG_SZ=320x320
-        elif [[ -n "$(media-ctl -p -d "$d" | grep imx636)" ]]; then
-            SENSOR_TYPE=imx636
+        elif [[ "$SENSOR_TYPE" = "imx636" ]]; then
             IMG_SZ=1280x720
             # inject eof of 64 bit
-            subdev_entity=$(media-ctl -d "$d" -p | awk -v entity="imx636" '$0 ~ "entity" && $0 ~ entity { in_entity=1 } in_entity && /device node name/ { print $NF; exit }')
             v4l2-ctl --device $subdev_entity --set-ctrl enable_end_of_frame_marker=3
         else
             echo "Unsupported sensor type!"
-            exit 1
+            continue;
         fi
 
-        if [[ -n "$(media-ctl -p -d $d | grep 11-003c)" ]]; then
-            if media-ctl -p -d "$d" | grep -q "/dev/video0"; then
-                DEV="/dev/video0"
-            elif media-ctl -p -d "$d" | grep -q "/dev/video8"; then
-                DEV="/dev/video8"
-            fi
-            I2CSLOT=11
-        elif [[ -n "$(media-ctl -p -d $d | grep 10-003c)" ]]; then
-            if media-ctl -p -d "$d" | grep -q "/dev/video0"; then
-                DEV="/dev/video0"
-            elif media-ctl -p -d "$d" | grep -q "/dev/video8"; then
-                DEV="/dev/video8"
-            fi
-            I2CSLOT=10
-        else
-            echo "Unsupported sensor type!"
-            exit 1
-        fi
+        DEV=$(media-ctl -d "$d" -e "rp1-cfe-csi2_ch0")
+        I2CSLOT=$(media-ctl -p -d "$d" | grep "entity" | grep -E "imx636|genx320" | awk '{print $5}')
 
         # Save the output to a file or process it
-        echo "Found sensor ${SENSOR_TYPE} in /dev/media$d with device $DEV"
+        echo "Found sensor ${SENSOR_TYPE} in /dev/media$d with device $DEV. Buffer size will be ${BUFFER_WIDTH}x${BUFFER_HEIGHT}"
 
-        # activate the link (always the same address)
+        # activate the link (always the same address on rpi5)
         echo "Activating csi link"
         media-ctl -d "$d" --links '"csi2":4 -> "rp1-cfe-csi2_ch0":0 [1]'
 
         echo "Setting v4l mode"
         # semi hard-coded setup, might have to be specified.
         if [ -c "$DEV" ]; then
-            media-ctl -d "$d" --set-v4l2 "\"${SENSOR_TYPE} ${I2CSLOT}-003c\":0 [fmt:Y8_1X8/4096x391]"
-            # only possible if sensor is turned on
-            # media-ctl -d "$d" --set-v4l2 "\"${SENSOR_TYPE} ${I2CSLOT}-003c\":0 [crop:(0,0)/${IMG_SZ}]"
-            v4l2-ctl -d $DEV --set-fmt-video=width=4096,height=391,pixelformat=GREY
+            media-ctl -d "$d" --set-v4l2 "\"${SENSOR_TYPE} ${I2CSLOT}\":0 [fmt:Y8_1X8/${BUFFER_WIDTH}x${BUFFER_HEIGHT}]"
+            # set crop mode can only be done after init. It is not required for streaming, but may help drivers to infer correct size.
+            # media-ctl -d "$d" --set-v4l2 "\"${SENSOR_TYPE} ${I2CSLOT}\":0 [crop:(0,0)/${IMG_SZ}]"
+            v4l2-ctl -d $DEV --set-fmt-video=width=${BUFFER_WIDTH},height=${BUFFER_HEIGHT},pixelformat=GREY
         else
             echo "Device is not correctly set up"
             exit 1


### PR DESCRIPTION
- Sensor biases:
  * Updated the default biases values to align with the latest specification
  * Extended the biases ranges to improve flexibility
    * bias_diff : [41; 51]
    * bias_diff_on: [24; 78]
    * bias_diff_off : [19; 127]
    * bias_fo : [19; 50]
    * bias_hpf: [0; 127]
    * bias_refr: [0; 127]
   
- Corrected the bias facility range and configuration setting
- Camera configuration:
    * Adjusted the boot delay parameter to resolve adapter boot failures on certain hardware setups
    * OpenEB path: Fixed V4L control settings via OpenEB that impacted loading and saving of camera configuration